### PR TITLE
change the job button to Associate PM jobs (for Demo purposes)

### DIFF
--- a/app/views/professions/show.html.erb
+++ b/app/views/professions/show.html.erb
@@ -9,7 +9,7 @@
     <div class="row justify-content-center">
         <h2>Your Roadmap for <%=@profession.track%></h2>
           <p>This is your <i><b>Truepath</b></i> for the <%= @profession.track %> track</p>
-        <a href="/professions/Product%20Management%20Intern/jobs" type="button" class="btn btn-primary">Find a Matching Job</a>
+        <a href="/professions/Associate%20product%20manager/jobs" type="button" class="btn btn-primary">Find a Matching Job</a>
     </div>
   </div>
 

--- a/app/views/professions/show.html.erb
+++ b/app/views/professions/show.html.erb
@@ -9,7 +9,7 @@
     <div class="row justify-content-center">
         <h2>Your Roadmap for <%=@profession.track%></h2>
           <p>This is your <i><b>Truepath</b></i> for the <%= @profession.track %> track</p>
-        <a href="/professions/Associate%20product%20manager/jobs" type="button" class="btn btn-primary">Find a Matching Job</a>
+        <a href="/professions/Associate%20product%20manager/jobs" type="button" class="btn btn-primary">Find your next job</a>
     </div>
   </div>
 


### PR DESCRIPTION
Changed the Find a Job button to Associate PM jobs (Hardcoded) for the Demo. As Louis is ticking the boxes. Can be easily changed though. Just couldn't do it 100% dynamic with the ticking of the boxes and so on. 

I think that would be a good solution for the Demo for now. Pressing the Jobs in the roadmap directly links you to those jobs. So possibility to integrate both methods into the USer Story, just the button is hardcoded 