### PR TITLE
Styled numbering

### DIFF
--- a/app/assets/stylesheets/pages/_questions.scss
+++ b/app/assets/stylesheets/pages/_questions.scss
@@ -1,3 +1,18 @@
+h5.card-title {
+    background-color: $eggplant;
+    width: 54px;
+    margin: 0px auto 10px;
+    padding: 2px 4px;
+    border-radius: 5px;
+    color: white;
+    font-weight: 600;
+    font-size: 0.8em;
+}
+
+p.card-text {
+  margin-top: 21px;
+}
+
 .answers {
   position: relative;
   overflow: hidden;

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -19,7 +19,7 @@
           <% end %>
           <div class="card" alt="First slide">
             <div class="card-body">
-              <h5 class="card-title text-center">Question <%= index + 1 %></h5>
+              <h5 class="card-title text-center"><%= index + 1 %> / <%= @questions.count %></h5>
               <p class="card-text text-center"><%=question.text.html_safe%></p>
               <div class=" d-flex justify-content-center ">
 


### PR DESCRIPTION
Rendered the styling of the question numbering to be less distracting, which would be more in line with the progress bar if we add it.

![image](https://user-images.githubusercontent.com/20980287/100920700-c6a33900-34db-11eb-9644-a8b2bfb36500.png)
