### PR TITLE
rest pages amended

### DIFF
--- a/app/controllers/professions_controller.rb
+++ b/app/controllers/professions_controller.rb
@@ -23,11 +23,11 @@ class ProfessionsController < ApplicationController
         description: "As Technical #{@title} in Zalando Marketing Services, you will shape the future of Europe's biggest fashion ad platform. You will own the data and machine learning infrastructure which is a key component in driving marketing value to Zalando brands. You will interact with Zalando merchants and brands as well as Zalando customers and influencers to develop a deep understanding of the relationships among customers, fashion products and fashion brands. You will work with Zalando engineers and applied scientists to build the data infrastructure and machine learning models necessary to capture these relationships and provide them to ad platform components as a means of driving efficiencies into the ZMS ad marketplace."
       },
       {
-        title: "#{@title} / product owner",
+        title: "Junior #{@title}",
         company: "interact.io",
         location: "Berlin",
         skills: ['strategic thinking', 'certification', 'ux'],
-        description: "We are seeking an ambitious, self-motivated technical #{@title} to help us design, develop and launch the next set of industry leading Enterprise Cloud Solutions and successfully deliver reference implementations of our software with key clients worldwide. Applicants should enjoy working in a fast paced and customer-oriented environment in a highly collaborative international team."
+        description: "We are seeking an ambitious, self-motivated junior #{@title} to help us design, develop and launch the next set of industry leading Enterprise Cloud Solutions and successfully deliver reference implementations of our software with key clients worldwide. Applicants should enjoy working in a fast paced and customer-oriented environment in a highly collaborative international team."
       }
     ]
   end

--- a/app/views/professions/compare.html.erb
+++ b/app/views/professions/compare.html.erb
@@ -1,25 +1,25 @@
 <h3>How does this sound?</h3>
 <div class="wrapper">
     <div class="first">
-      <a href="/professions/<%= Profession.where(track: 'Product Management').ids[0] %>" class="btn btn-info btn-lg btn-block">Product Mangager</a>
+      <a href="/professions/<%= Profession.where(track: 'Product Management').ids[0] %>" class="btn btn-info btn-lg btn-block">Product Manager</a>
       <div id="D">
-      <h5>Connection between product developement and marketing</h5>
+      <h5>Connection between Product Developement and Marketing</h5>
       </div>
       <div id="K">
       <h4>Knowledge</h4>
       <ul>
-      <li>Bachelor degree or Certificate</li>
-      <li>Product management techniques</li>
-      <li>Lean methodes</li>
+      <li>Bachelor Degree or Certificate</li>
+      <li>Product Management Techniques</li>
+      <li>Lean Methodes</li>
       </ul>
       </div>
 
       <div id="P">
       <h4>Personality</h4>
       <ul>
-      <li>Enterpreneurial</li>
+      <li>Entrepreneurial</li>
       <li>Analytical thinking</li>
-      <li>Goal and product oriented</li>
+      <li>Goal and Product Oriented</li>
       </ul>
     </div>
     <div id="S">
@@ -31,22 +31,22 @@
     <div class="second">
       <a href="#" class="btn btn-info btn-lg btn-block">Software Engineer</a>
       <div id="D">
-      <h5>Combining business sense with programming know-how</h5>
+      <h5>Combining Business Sense with Programming Know-How</h5>
       </div>
       <div id="K">
       <h4>Knowledge</h4>
       <ul>
-      <li>Bachelor degree or Certificate</li>
-      <li>"Hands on" experience</li>
-      <li>General IT and Mathematics knowledge</li>
+      <li>Bachelor Degree or Certificate</li>
+      <li>"Hands-on" Experience</li>
+      <li>General IT and Mathematics Knowledge</li>
       </ul>
       </div>
       <div id="P">
       <h4>Personality</h4>
       <ul>
-      <li>Outgoing personality</li>
+      <li>Outgoing Personality</li>
       <li>Eager to learn</li>
-      <li>Great affinity for Task & Self management</li>
+      <li>Great affinity for Task & Self Management</li>
       </ul>
       </div>
       <div id="S">

--- a/app/views/professions/compare.html.erb
+++ b/app/views/professions/compare.html.erb
@@ -3,14 +3,14 @@
     <div class="first">
       <a href="/professions/<%= Profession.where(track: 'Product Management').ids[0] %>" class="btn btn-info btn-lg btn-block">Product Manager</a>
       <div id="D">
-      <h5>Connection between Product Developement and Marketing</h5>
+      <h5>Connection between Product Development and Marketing</h5>
       </div>
       <div id="K">
       <h4>Knowledge</h4>
       <ul>
       <li>Bachelor Degree or Certificate</li>
       <li>Product Management Techniques</li>
-      <li>Lean Methodes</li>
+      <li>Lean Methods</li>
       </ul>
       </div>
 

--- a/app/views/professions/jobs.html.erb
+++ b/app/views/professions/jobs.html.erb
@@ -90,7 +90,14 @@
 </style>
 
 <div class="exit-btn-wrapper"><%= link_to :back do %><div class= "btn exit-btn">X</div><% end %></div>
-<h3 class= "jobs-heading">Relevant openings for <%= @jobs[0][:title] %></h3>
+
+  <div class="container">
+    <div class="row justify-content-center">
+        <h1><i><b>Your True </b></i> Current Openings as a <%= @jobs[0][:title] %></h1>
+        <p>This selection reflects the most current openings for <%= @jobs[0][:title] %> and match your current step on your <b>Truepath</b>. See for yourself and apply where you see best fit.</p>
+    </div>
+  </div>
+
 <div id="jobs-carousel" class="carousel slide" data-wrap="false" data-interval="false" data-ride="carousel">
   <ol class="carousel-indicators">
     <!-- iterate over questions (li) -->
@@ -119,7 +126,7 @@
                 <ul class="job-tags">
                   <% if job[:company] == 'Zalando' %>
                     <li>Remote</li>
-                    <li>Above-average salary</li>
+                    <li>Above-Average Salary</li>
                   <% elsif job[:company] == 'ImmoScout24' %>
                     <li>Flexible Hours</li>
                     <li>Central Location</li>


### PR DESCRIPTION
Compare page: typos
Job Openings: change of style and wording for Title and subtitle (along the other pages) + Typos
TO DO: - the job opening page needs to call the step, NOT the profession! - the application link
